### PR TITLE
Markdown lexer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Run Cargo Tests
+on:
+  push:
+    branches: ["main"]
+    paths-ignore: ["README.md", ".gitignore", ".github/**"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,12 @@ version = 4
 [[package]]
 name = "rust_mark"
 version = "0.1.0"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+unicode-segmentation = "1.12.0"

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -10,7 +10,7 @@ pub enum Token {
     OpenParenthesis,
     CloseParenthesis,
     Whitespace,
-    Escape(char),
+    Escape(String),
     Newline,
 }
 pub fn tokenize(markdown_line: &str) -> Vec<Token> {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -26,7 +26,6 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
     let chars = Vec::from_iter(markdown_line.graphemes(true));
 
     // Loop through each character, and perform foward lookups for *
-    let mut recent_emphasis: Token = Token::Whitespace;
     let mut i = 0;
     while i < str_len {
         match chars[i] {
@@ -35,16 +34,11 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                 push_buffer_to_tokens(&mut tokens, &mut buffer);
 
                 // Perform forward lookup for another *
-                if (i + 1 < str_len) && chars[i + 1] == "*" && recent_emphasis != Token::Asterisk {
+                if (i + 1 < str_len) && chars[i + 1] == "*" {
                     tokens.push(Token::DoubleAsterisk);
                     i += 1;
                 } else {
                     tokens.push(Token::Asterisk);
-                    if recent_emphasis == Token::Asterisk {
-                        recent_emphasis = Token::Whitespace;
-                    } else {
-                        recent_emphasis = Token::Asterisk;
-                    }
                 }
             }
             "\\" => {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -98,7 +98,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
 fn push_buffer_to_tokens(tokens: &mut Vec<Token>, buffer: &mut String) {
     if !&buffer.is_empty() {
         tokens.push(Token::Text(buffer.to_string()));
-        buffer.drain(..&buffer.len());
+        buffer.clear();
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -6,4 +6,6 @@ pub enum Token {
     CloseBracket,
     OpenParenthesis,
     CloseParenthesis,
+    Whitespace,
+    Newline,
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -37,6 +37,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                     }
                 }
             }
+            " " => tokens.push(Token::Whitespace),
             // Note that graphemes() returns strings because graphemes can consist of things like a
             // char + a modifier
             _ => tokens.push(Token::Text(String::from(chars[i]))),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,4 +1,6 @@
 use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Debug, PartialEq)]
 pub enum Token {
     Text(String),
     Asterisk,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -7,5 +7,6 @@ pub enum Token {
     OpenParenthesis,
     CloseParenthesis,
     Whitespace,
+    Escape(char),
     Newline,
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,3 +1,4 @@
+use unicode_segmentation::UnicodeSegmentation;
 pub enum Token {
     Text(String),
     Asterisk,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -11,7 +11,7 @@ pub enum Token {
     CloseParenthesis,
     Whitespace,
     Escape(String),
-    Newline,
+    // Newline,
 }
 pub fn tokenize(markdown_line: &str) -> Vec<Token> {
     let mut tokens: Vec<Token> = Vec::new();

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -75,5 +75,11 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
         i += 1;
     }
 
+    // if the current buffer isn't empty, append a Text token to the Vec<Token>
+    if !&buffer.is_empty() {
+        tokens.push(Token::Text(buffer.clone()));
+        buffer.drain(..buffer.len());
+    }
+
     tokens
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -76,6 +76,11 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
 
                 tokens.push(Token::Whitespace);
             }
+            "" | "\n" => {
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
+
+                tokens.push(Token::Newline);
+            }
             // Note that graphemes() returns strings because graphemes can consist of things like a
             // char + a modifier
             _ => buffer.push_str(chars[i]),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -13,3 +13,37 @@ pub enum Token {
     Escape(char),
     Newline,
 }
+pub fn tokenize(markdown_line: &str) -> Vec<Token> {
+    let mut tokens: Vec<Token> = Vec::new();
+    let str_len = markdown_line.graphemes(true).count();
+    let chars = Vec::from_iter(markdown_line.graphemes(true));
+    // Loop through each character, and perform foward lookups for *
+    let mut recent_emphasis: Token = Token::Whitespace;
+    let mut i = 0;
+    while i < str_len {
+        match chars[i] {
+            "*" => {
+                // Perform forward lookup for another *
+                if (i + 1 < str_len) && chars[i + 1] == "*" && recent_emphasis != Token::Asterisk {
+                    tokens.push(Token::DoubleAsterisk);
+                    recent_emphasis = Token::DoubleAsterisk;
+                    i += 1;
+                } else {
+                    tokens.push(Token::Asterisk);
+                    if recent_emphasis == Token::Asterisk {
+                        recent_emphasis = Token::Whitespace;
+                    } else {
+                        recent_emphasis = Token::Asterisk;
+                    }
+                }
+            }
+            // Note that graphemes() returns strings because graphemes can consist of things like a
+            // char + a modifier
+            _ => tokens.push(Token::Text(String::from(chars[i]))),
+        }
+
+        i += 1;
+    }
+
+    tokens
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,0 +1,9 @@
+pub enum Token {
+    Text(String),
+    Asterisk,
+    DoubleAsterisk,
+    OpenBracket,
+    CloseBracket,
+    OpenParenthesis,
+    CloseParenthesis,
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -96,3 +96,6 @@ fn push_buffer_to_tokens(tokens: &mut Vec<Token>, buffer: &mut String) {
         buffer.drain(..&buffer.len());
     }
 }
+
+#[cfg(test)]
+mod lexer_test;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -19,6 +19,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
 
     let str_len = markdown_line.graphemes(true).count();
     let chars = Vec::from_iter(markdown_line.graphemes(true));
+
     // Loop through each character, and perform foward lookups for *
     let mut recent_emphasis: Token = Token::Whitespace;
     let mut i = 0;
@@ -26,10 +27,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
         match chars[i] {
             "*" => {
                 // if the current buffer isn't empty, append a Text token to the Vec<Token>
-                if !&buffer.is_empty() {
-                    tokens.push(Token::Text(buffer.clone()));
-                    buffer.drain(..buffer.len());
-                }
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
 
                 // Perform forward lookup for another *
                 if (i + 1 < str_len) && chars[i + 1] == "*" && recent_emphasis != Token::Asterisk {
@@ -45,11 +43,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                 }
             }
             "\\" => {
-                // if the current buffer isn't empty, append a Text token to the Vec<Token>
-                if !&buffer.is_empty() {
-                    tokens.push(Token::Text(buffer.clone()));
-                    buffer.drain(..buffer.len());
-                }
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
 
                 if i + 1 < str_len {
                     tokens.push(Token::Escape(String::from(chars[i + 1])));
@@ -59,11 +53,7 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                 }
             }
             " " => {
-                // if the current buffer isn't empty, append a Text token to the Vec<Token>
-                if !&buffer.is_empty() {
-                    tokens.push(Token::Text(buffer.clone()));
-                    buffer.drain(..buffer.len());
-                }
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
 
                 tokens.push(Token::Whitespace);
             }
@@ -75,11 +65,15 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
         i += 1;
     }
 
-    // if the current buffer isn't empty, append a Text token to the Vec<Token>
-    if !&buffer.is_empty() {
-        tokens.push(Token::Text(buffer.clone()));
-        buffer.drain(..buffer.len());
-    }
+    // If the current buffer isn't empty when the loop is over, append it to the tokens vector
+    push_buffer_to_tokens(&mut tokens, &mut buffer);
 
     tokens
+}
+
+fn push_buffer_to_tokens(tokens: &mut Vec<Token>, buffer: &mut String) {
+    if !&buffer.is_empty() {
+        tokens.push(Token::Text(buffer.to_string()));
+        buffer.drain(..&buffer.len());
+    }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -26,7 +26,6 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                 // Perform forward lookup for another *
                 if (i + 1 < str_len) && chars[i + 1] == "*" && recent_emphasis != Token::Asterisk {
                     tokens.push(Token::DoubleAsterisk);
-                    recent_emphasis = Token::DoubleAsterisk;
                     i += 1;
                 } else {
                     tokens.push(Token::Asterisk);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -36,6 +36,15 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                     }
                 }
             }
+            "\\" => {
+                if i + 1 < str_len {
+                    tokens.push(Token::Escape(String::from(chars[i + 1])));
+                    i += 1;
+                } else {
+                    tokens.push(Token::Text(String::from(chars[i + 1]))); // TODO Change later to add it to the
+                }
+                // buffer
+            }
             " " => tokens.push(Token::Whitespace),
             // Note that graphemes() returns strings because graphemes can consist of things like a
             // char + a modifier

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -13,6 +13,7 @@ pub enum Token {
     Escape(String),
     // Newline,
 }
+
 pub fn tokenize(markdown_line: &str) -> Vec<Token> {
     let mut tokens: Vec<Token> = Vec::new();
     let mut buffer: String = String::new();

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -52,6 +52,26 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
                     buffer.push_str(chars[i]);
                 }
             }
+            "[" => {
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
+
+                tokens.push(Token::OpenBracket);
+            }
+            "]" => {
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
+
+                tokens.push(Token::CloseBracket);
+            }
+            "(" => {
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
+
+                tokens.push(Token::OpenParenthesis);
+            }
+            ")" => {
+                push_buffer_to_tokens(&mut tokens, &mut buffer);
+
+                tokens.push(Token::CloseParenthesis);
+            }
             " " => {
                 push_buffer_to_tokens(&mut tokens, &mut buffer);
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -11,10 +11,14 @@ pub enum Token {
     CloseParenthesis,
     Whitespace,
     Escape(String),
-    // Newline,
+    Newline,
 }
 
 pub fn tokenize(markdown_line: &str) -> Vec<Token> {
+    if markdown_line.is_empty() {
+        return vec![Token::Newline];
+    }
+
     let mut tokens: Vec<Token> = Vec::new();
     let mut buffer: String = String::new();
 

--- a/src/lexer/lexer_test.rs
+++ b/src/lexer/lexer_test.rs
@@ -11,6 +11,11 @@ fn test_lexer_whitespace() {
 }
 
 #[test]
+fn test_lexer_newline() {
+    assert_eq!(tokenize("\n"), vec![Newline]);
+}
+
+#[test]
 fn test_lexer_italic() {
     assert_eq!(
         tokenize("*italic*"),

--- a/src/lexer/lexer_test.rs
+++ b/src/lexer/lexer_test.rs
@@ -1,0 +1,111 @@
+use crate::lexer::{Token::*, *};
+
+#[test]
+fn test_lexer_text() {
+    assert_eq!(tokenize("Hello!"), vec![Text(String::from("Hello!"))]);
+}
+
+#[test]
+fn test_lexer_whitespace() {
+    assert_eq!(tokenize(" "), vec![Whitespace]);
+}
+
+#[test]
+fn test_lexer_italic() {
+    assert_eq!(
+        tokenize("*italic*"),
+        vec![Asterisk, Text(String::from("italic")), Asterisk]
+    );
+}
+
+#[test]
+fn test_lexer_bold() {
+    assert_eq!(
+        tokenize("**bold**"),
+        vec![DoubleAsterisk, Text(String::from("bold")), DoubleAsterisk]
+    );
+}
+
+#[test]
+fn test_lexer_mixed_asterisks() {
+    assert_eq!(
+        tokenize("***bold + italic***"),
+        vec![
+            DoubleAsterisk,
+            Asterisk,
+            Text(String::from("bold")),
+            Whitespace,
+            Text(String::from("+")),
+            Whitespace,
+            Text(String::from("italic")),
+            DoubleAsterisk,
+            Asterisk
+        ]
+    );
+}
+
+#[test]
+fn test_lexer_link() {
+    assert_eq!(
+        tokenize("More information available [here](https://www.example.com)"),
+        vec![
+            Text(String::from("More")),
+            Whitespace,
+            Text(String::from("information")),
+            Whitespace,
+            Text(String::from("available")),
+            Whitespace,
+            OpenBracket,
+            Text(String::from("here")),
+            CloseBracket,
+            OpenParenthesis,
+            Text(String::from("https://www.example.com")),
+            CloseParenthesis
+        ]
+    );
+}
+
+#[test]
+fn test_lexer_emphasis_in_link() {
+    assert_eq!(
+        tokenize("[*italic **bold+italic***](https://www.example.com)"),
+        vec![
+            OpenBracket,
+            Asterisk,
+            Text(String::from("italic")),
+            Whitespace,
+            DoubleAsterisk,
+            Text(String::from("bold+italic")),
+            DoubleAsterisk,
+            Asterisk,
+            CloseBracket,
+            OpenParenthesis,
+            Text(String::from("https://www.example.com")),
+            CloseParenthesis
+        ]
+    );
+}
+
+#[test]
+fn test_lexer_unicode() {
+    assert_eq!(
+        tokenize("これは正解です。"),
+        vec![Text(String::from("これは正解です。"))]
+    );
+}
+
+#[test]
+fn test_lexer_unicode_mixed() {
+    assert_eq!(
+        tokenize("**これ** means \"This\"!"),
+        vec![
+            DoubleAsterisk,
+            Text(String::from("これ")),
+            DoubleAsterisk,
+            Whitespace,
+            Text(String::from("means")),
+            Whitespace,
+            Text(String::from("\"This\"!"))
+        ]
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 mod io;
+mod parser;
 
 use io::read_file;
 use std::env::args;
+
 fn main() {
     println!("Hello, world!");
     let args: Vec<String> = args().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod io;
+mod lexer;
 mod parser;
 
 use io::read_file;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,23 @@
+pub enum MdBlockElement {
+    Header {
+        level: u8,
+        content: Vec<MdInlineElement>,
+    },
+    Paragraph {
+        content: Vec<MdInlineElement>,
+    },
+    CodeBlock {
+        lines: Vec<String>,
+    },
+    UnorderedList {
+        items: Vec<MdBlockElement>,
+    },
+    HorizontalRule,
+}
+
+pub enum MdInlineElement {
+    Text { content: String },
+    Bold { content: Vec<MdBlockElement> },
+    Italic { content: String },
+    Link { text: String, url: String }, // Look into if this is a good or bad way to do this
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub enum MdBlockElement {
     Header {
         level: u8,
@@ -10,14 +11,30 @@ pub enum MdBlockElement {
         lines: Vec<String>,
     },
     UnorderedList {
-        items: Vec<MdBlockElement>,
+        items: Vec<MdListItem>,
     },
     HorizontalRule,
 }
 
-pub enum MdInlineElement {
-    Text { content: String },
-    Bold { content: Vec<MdInlineElement> },
-    Italic { content: String },
-    Link { text: String, url: String }, // Look into if this is a good or bad way to do this
+#[derive(Debug)]
+pub struct MdListItem {
+    content: Vec<MdBlockElement>,
 }
+
+#[derive(Debug)]
+pub enum MdInlineElement {
+    Text {
+        content: String,
+    },
+    Bold {
+        content: Vec<MdInlineElement>,
+    },
+    Italic {
+        content: Vec<MdInlineElement>,
+    },
+    Link {
+        text: Vec<MdInlineElement>,
+        url: String,
+    },
+}
+

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,7 +17,7 @@ pub enum MdBlockElement {
 
 pub enum MdInlineElement {
     Text { content: String },
-    Bold { content: Vec<MdBlockElement> },
+    Bold { content: Vec<MdInlineElement> },
     Italic { content: String },
     Link { text: String, url: String }, // Look into if this is a good or bad way to do this
 }


### PR DESCRIPTION
# Lexer
In this PR, I added a custom Lexer for markdown input, with support for `*`, `**`, `(`, `)`, `[`, `]`, Text, Escape Chars, Whitespaces, and Newlines

## Details
- `lexer.rs`
  - There is now an enum for `Token` types supporting all listed above
  - There is now a `tokenize()` function that takes in markdown content as a string and returns a `Vec<Token>`
- `lexer/lexer_tests.rs`
  - Tests have been written to cover the following:
    - Bold
    - Italic
    - Mixed emphasis
    - Links
    - Emphasis in links
    - Plain text
    - Whitespace
    - Newlines
    - Unicode Chars
- `main.rs`
  - The `lexer` module has been added
- `Cargo.lock` and `Cargo.toml`
  - `unicode-segmentation` has been added as a dependency to support graphemes