### PR TITLE
Add support for GitHub flavor tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,12 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "rust_mark"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "dirs",
@@ -273,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -319,44 +313,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "unicode-ident"
@@ -466,6 +458,3 @@ name = "winnow"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
-dependencies = [
- "memchr",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_mark"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 clap = { version = "4.5.40", features = ["derive"] }
 dirs = "6.0.0"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.8.23"
+toml = "0.9.2"
 unicode-segmentation = "1.12.0"
 unicode_categories = "0.1.1"
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -106,6 +106,11 @@ pub fn tokenize(markdown_line: &str) -> Vec<Token> {
 
                 tokens.push(Token::CloseParenthesis);
             }
+            "|" => {
+                push_buffer_to_collection(&mut tokens, &mut buffer);
+
+                tokens.push(Token::TableCellSeparator);
+            }
             "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
                 // Check for valid ordered list marker
                 if i + 2 < str_len && chars[i + 1] == "." && chars[i + 2] == " " {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ static CONFIG: OnceLock<Config> = OnceLock::new();
 #[derive(Parser, Debug)]
 #[command(
     author = "Zackary Liel",
-    version = "0.1.0",
+    version = "1.0.0",
     about = "A Commonmark compliant markdown parser and static site generator.",
     override_usage = "rust_mark [OPTIONS] <INPUT_DIR>"
 )]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -358,7 +358,7 @@ pub fn parse_table(line: Vec<Token>) -> MdBlockElement {
 /// Helper function to split a row of tokens into individual cells.
 ///
 /// By removing the starting and ending "|" characters, it ensures that the row is
-/// split into the proper number of cells,.
+/// split into the proper number of cells.
 fn split_row(row: &[Token]) -> Vec<Vec<Token>> {
     let mut cells: Vec<Vec<Token>> = row
         .split(|token| *token == Token::TableCellSeparator)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -281,6 +281,30 @@ fn parse_heading(line: Vec<Token>) -> MdBlockElement {
     }
 }
 
+/// Helper function to split a row of tokens into individual cells.
+///
+/// By removing the starting and ending "|" characters, it ensures that the row is
+/// split into the proper number of cells,.
+fn split_row(row: &[Token]) -> Vec<Vec<Token>> {
+    let mut cells: Vec<Vec<Token>> = row
+        .split(|token| *token == Token::TableCellSeparator)
+        .map(|tokens| tokens.to_vec())
+        .collect();
+
+    if let Some(first) = cells.first() {
+        if first.is_empty() {
+            cells.remove(0);
+        }
+    }
+    if let Some(last) = cells.last() {
+        if last.is_empty() {
+            cells.pop();
+        }
+    }
+
+    cells
+}
+
 /// Parses a vector of tokens into a vector of inline Markdown elements (i.e. links, images,
 /// bold/italics, etc.).
 ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -226,6 +226,7 @@ fn parse_codeblock(line: Vec<Token>) -> MdBlockElement {
             Some(Token::CloseParenthesis) => line_buffer.push(')'),
             Some(Token::OpenBracket) => line_buffer.push('['),
             Some(Token::CloseBracket) => line_buffer.push(']'),
+            Some(Token::TableCellSeparator) => line_buffer.push('|'),
             Some(Token::EmphasisRun { delimiter, length }) => {
                 line_buffer.push_str(delimiter.to_string().repeat(*length).as_str())
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,10 @@
 //! It provides functions to parse block-level elements like headings, lists, and code blocks,
 //! as well as inline elements like links, images, and emphasis.
 
-use crate::types::{Delimiter, MdBlockElement, MdInlineElement, MdListItem, Token, TokenCursor};
+use crate::types::{
+    Delimiter, MdBlockElement, MdInlineElement, MdListItem, MdTableCell, TableAlignment, Token,
+    TokenCursor,
+};
 use crate::utils::push_buffer_to_collection;
 
 /// Parses a vector of tokenized markdown lines into a vector of block-level Markdown elements.
@@ -376,6 +379,7 @@ pub fn parse_inline(markdown_tokens: Vec<Token>) -> Vec<MdInlineElement> {
             Token::OpenParenthesis => buffer.push('('),
             Token::CloseParenthesis => buffer.push(')'),
             Token::ThematicBreak => buffer.push_str("---"),
+            Token::TableCellSeparator => buffer.push('|'),
             _ => push_buffer_to_collection(&mut parsed_inline_elements, &mut buffer),
         }
 
@@ -414,6 +418,7 @@ fn parse_code_span(cursor: &mut TokenCursor) -> String {
             Token::CloseParenthesis => code_content.push(')'),
             Token::OpenBracket => code_content.push('['),
             Token::CloseBracket => code_content.push(']'),
+            Token::TableCellSeparator => code_content.push('|'),
             Token::EmphasisRun { delimiter, length } => {
                 code_content.push_str(delimiter.to_string().repeat(*length).as_str())
             }
@@ -512,6 +517,7 @@ where
             Token::ThematicBreak => label_buffer.push_str("---"),
             Token::OpenParenthesis => label_buffer.push('('),
             Token::CloseParenthesis => label_buffer.push(')'),
+            Token::TableCellSeparator => label_buffer.push('|'),
             _ => {}
         }
         cursor.advance();
@@ -553,6 +559,7 @@ where
                 Token::Escape(ch) => uri.push_str(format!("\\{ch}").as_str()),
                 Token::Whitespace => is_building_title = true,
                 Token::ThematicBreak => uri.push_str("---"),
+                Token::TableCellSeparator => uri.push('|'),
                 _ => {}
             }
         } else {
@@ -576,6 +583,7 @@ where
                 Token::OpenBracket => title.push('['),
                 Token::CloseBracket => title.push(']'),
                 Token::OpenParenthesis => title.push('('),
+                Token::TableCellSeparator => title.push('|'),
                 Token::Tab => title.push('\t'),
                 Token::Newline => title.push_str("\\n"),
                 Token::Whitespace => title.push(' '),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -847,6 +847,9 @@ pub fn group_lines_to_blocks(mut tokenized_lines: Vec<Vec<Token>>) -> Vec<Vec<To
             Some(Token::Text(_)) => {
                 group_text_lines(&mut blocks, &mut current_block, &mut previous_block, line);
             }
+            Some(Token::TableCellSeparator) => {
+                group_table_rows(&mut blocks, &mut current_block, &mut previous_block, line);
+            }
             _ => {
                 // Catch-all for everything else
                 current_block.extend(line.to_owned());
@@ -860,6 +863,26 @@ pub fn group_lines_to_blocks(mut tokenized_lines: Vec<Vec<Token>>) -> Vec<Vec<To
         current_block.clear();
     }
     blocks
+}
+
+fn group_table_rows(
+    blocks: &mut Vec<Vec<Token>>,
+    current_block: &mut Vec<Token>,
+    previous_block: &mut Vec<Token>,
+    line: &mut Vec<Token>,
+) {
+    if let Some(previous_line_start) = previous_block.first() {
+        if previous_line_start == &Token::TableCellSeparator {
+            previous_block.push(Token::Newline);
+            previous_block.extend(line.to_owned());
+            blocks.pop();
+            blocks.push(previous_block.clone());
+        } else {
+            current_block.extend(line.to_owned());
+        }
+    } else {
+        current_block.extend(line.to_owned());
+    }
 }
 
 /// Groups text lines into blocks based on the previous block's content.

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1594,5 +1594,75 @@ mod html_generation {
                 "<ol><li><p><b>Bold Item 1</b></p></li><li><p><i>Italic Item 2</i></p></li><li><p><a href=\"http://example.com\" target=\"_blank\">Link Item 3⮺</a></p></li><li><p><img src=\"http://example.com/image.png\" alt=\"Image Item 4\" title=\"Some title\"/></p></li></ol>"
             );
         }
+
+        #[test]
+        fn table_all_left_align() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![
+                    tokenize("| Header 1 | Header 2 |"),
+                    tokenize("| :-- | :-- |"),
+                    tokenize("| Cell 1 | Cell 2 |"),
+                    tokenize("| Cell 3 | Cell 4 |")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<table><thead><tr><th style=\"text-align:left;\"> Header 1 </th><th style=\"text-align:left;\"> Header 2 </th></tr></thead><tbody><tr><td style=\"text-align:left;\"> Cell 1 </td><td style=\"text-align:left;\"> Cell 2 </td></tr><tr><td style=\"text-align:left;\"> Cell 3 </td><td style=\"text-align:left;\"> Cell 4 </td></tr></tbody></table>"
+            );
+        }
+
+        #[test]
+        fn table_mixed_align() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![
+                    tokenize("| Header 1 | Header 2 | Header 3 |"),
+                    tokenize("| :-- | :-: | --: |"),
+                    tokenize("| Cell 1 | Cell 2 | Cell 3 |"),
+                    tokenize("| Cell 4 | Cell 5 | Cell 6 |")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<table><thead><tr><th style=\"text-align:left;\"> Header 1 </th><th style=\"text-align:center;\"> Header 2 </th><th style=\"text-align:right;\"> Header 3 </th></tr></thead><tbody><tr><td style=\"text-align:left;\"> Cell 1 </td><td style=\"text-align:center;\"> Cell 2 </td><td style=\"text-align:right;\"> Cell 3 </td></tr><tr><td style=\"text-align:left;\"> Cell 4 </td><td style=\"text-align:center;\"> Cell 5 </td><td style=\"text-align:right;\"> Cell 6 </td></tr></tbody></table>"
+            );
+        }
+
+        #[test]
+        fn table_no_align() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![
+                    tokenize("| Header 1 | Header 2 |"),
+                    tokenize("| -- | -- |"),
+                    tokenize("| Cell 1 | Cell 2 |"),
+                    tokenize("| Cell 3 | Cell 4 |")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<table><thead><tr><th style=\"text-align:left;\"> Header 1 </th><th style=\"text-align:left;\"> Header 2 </th></tr></thead><tbody><tr><td style=\"text-align:left;\"> Cell 1 </td><td style=\"text-align:left;\"> Cell 2 </td></tr><tr><td style=\"text-align:left;\"> Cell 3 </td><td style=\"text-align:left;\"> Cell 4 </td></tr></tbody></table>"
+            );
+        }
+
+        #[test]
+        fn table_with_inline_content() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![
+                    tokenize("| Header 1 | Header 2 |"),
+                    tokenize("| :-- | :-- |"),
+                    tokenize("| **Bold Cell** | *Italic Cell* |"),
+                    tokenize(
+                        "| [Link](http://example.com) | ![Image](http://example.com/image.png) |"
+                    )
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<table><thead><tr><th style=\"text-align:left;\"> Header 1 </th><th style=\"text-align:left;\"> Header 2 </th></tr></thead><tbody><tr><td style=\"text-align:left;\"> <b>Bold Cell</b> </td><td style=\"text-align:left;\"> <i>Italic Cell</i> </td></tr><tr><td style=\"text-align:left;\"> <a href=\"http://example.com\" target=\"_blank\">Link⮺</a> </td><td style=\"text-align:left;\"> <img src=\"http://example.com/image.png\" alt=\"Image\"/> </td></tr></tbody></table>"
+            );
+        }
     }
 }

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -317,7 +317,10 @@ mod inline {
 }
 
 mod block {
-    use crate::parser::{group_lines_to_blocks, parse_blocks};
+    use crate::{
+        parser::{group_lines_to_blocks, parse_blocks},
+        types::{MdTableCell, TableAlignment},
+    };
 
     use super::*;
 
@@ -921,6 +924,330 @@ mod block {
                 language: Some(String::from("rust")),
                 lines: vec![String::from("\nfn main() {}\n")]
             })
+        );
+    }
+
+    #[test]
+    fn table_all_left_align() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(group_lines_to_blocks(vec![
+                tokenize("| Header 1 | Header 2 |"),
+                tokenize("| :-- | :-- |"),
+                tokenize("| Cell 1 | Cell 2 |"),
+                tokenize("| Cell 3 | Cell 4 |")
+            ])),
+            vec![Table {
+                headers: vec![
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 1 ")
+                        }],
+                        alignment: TableAlignment::Left,
+                        is_header: true,
+                    },
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 2 ")
+                        }],
+                        alignment: TableAlignment::Left,
+                        is_header: true,
+                    }
+                ],
+                body: vec![
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 1 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 2 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        }
+                    ],
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 3 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 4 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        }
+                    ]
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn table_mixed_align() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(group_lines_to_blocks(vec![
+                tokenize("| Header 1 | Header 2 | Header 3 |"),
+                tokenize("| :-- | :-: | --: |"),
+                tokenize("| Cell 1 | Cell 2 | Cell 3 |"),
+                tokenize("| Cell 4 | Cell 5 | Cell 6 |")
+            ])),
+            vec![Table {
+                headers: vec![
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 1 ")
+                        }],
+                        alignment: TableAlignment::Left,
+                        is_header: true,
+                    },
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 2 ")
+                        }],
+                        alignment: TableAlignment::Center,
+                        is_header: true,
+                    },
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 3 ")
+                        }],
+                        alignment: TableAlignment::Right,
+                        is_header: true,
+                    }
+                ],
+                body: vec![
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 1 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 2 ")
+                            }],
+                            alignment: TableAlignment::Center,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 3 ")
+                            }],
+                            alignment: TableAlignment::Right,
+                            is_header: false,
+                        }
+                    ],
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 4 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 5 ")
+                            }],
+                            alignment: TableAlignment::Center,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 6 ")
+                            }],
+                            alignment: TableAlignment::Right,
+                            is_header: false,
+                        }
+                    ]
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn table_no_align() {
+        init_test_config();
+
+        assert_eq!(
+            parse_blocks(group_lines_to_blocks(vec![
+                tokenize("| Header 1 | Header 2 |"),
+                tokenize("| -- | -- |"),
+                tokenize("| Cell 1 | Cell 2 |"),
+                tokenize("| Cell 3 | Cell 4 |")
+            ])),
+            vec![Table {
+                headers: vec![
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 1 ")
+                        }],
+                        alignment: TableAlignment::None,
+                        is_header: true,
+                    },
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 2 ")
+                        }],
+                        alignment: TableAlignment::None,
+                        is_header: true,
+                    }
+                ],
+                body: vec![
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 1 ")
+                            }],
+                            alignment: TableAlignment::None,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 2 ")
+                            }],
+                            alignment: TableAlignment::None,
+                            is_header: false,
+                        }
+                    ],
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 3 ")
+                            }],
+                            alignment: TableAlignment::None,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 4 ")
+                            }],
+                            alignment: TableAlignment::None,
+                            is_header: false,
+                        }
+                    ]
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn table_with_inline_content() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(group_lines_to_blocks(vec![
+                tokenize("| Header 1 | Header 2 |"),
+                tokenize("| :-- | :-- |"),
+                tokenize("| **Bold Cell** | *Italic Cell* |"),
+                tokenize("| [Link](http://example.com) | ![Image](http://example.com/image.png) |")
+            ])),
+            vec![Table {
+                headers: vec![
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 1 ")
+                        }],
+                        alignment: TableAlignment::Left,
+                        is_header: true,
+                    },
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 2 ")
+                        }],
+                        alignment: TableAlignment::Left,
+                        is_header: true,
+                    }
+                ],
+                body: vec![
+                    vec![
+                        MdTableCell {
+                            content: vec![
+                                Text {
+                                    content: " ".to_string()
+                                },
+                                Bold {
+                                    content: vec![Text {
+                                        content: String::from("Bold Cell")
+                                    }]
+                                },
+                                Text {
+                                    content: " ".to_string()
+                                }
+                            ],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![
+                                Text {
+                                    content: " ".to_string()
+                                },
+                                Italic {
+                                    content: vec![Text {
+                                        content: String::from("Italic Cell")
+                                    }]
+                                },
+                                Text {
+                                    content: " ".to_string()
+                                }
+                            ],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        }
+                    ],
+                    vec![
+                        MdTableCell {
+                            content: vec![
+                                Text {
+                                    content: " ".to_string()
+                                },
+                                Link {
+                                    text: vec![Text {
+                                        content: String::from("Link")
+                                    }],
+                                    title: None,
+                                    url: String::from("http://example.com")
+                                },
+                                Text {
+                                    content: " ".to_string()
+                                }
+                            ],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![
+                                Text {
+                                    content: " ".to_string()
+                                },
+                                Image {
+                                    alt_text: String::from("Image"),
+                                    title: None,
+                                    url: String::from("http://example.com/image.png")
+                                },
+                                Text {
+                                    content: " ".to_string()
+                                }
+                            ],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        }
+                    ]
+                ]
+            }]
         );
     }
 }

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -1250,6 +1250,123 @@ mod block {
             }]
         );
     }
+
+    #[test]
+    fn table_with_empty_cells() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(group_lines_to_blocks(vec![
+                tokenize("| Header 1 | Header 2 |"),
+                tokenize("| :-- | :-- |"),
+                tokenize("| Cell 1 ||"),
+                tokenize("|| Cell 4 |")
+            ])),
+            vec![Table {
+                headers: vec![
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 1 ")
+                        }],
+                        alignment: TableAlignment::Left,
+                        is_header: true,
+                    },
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 2 ")
+                        }],
+                        alignment: TableAlignment::Left,
+                        is_header: true,
+                    }
+                ],
+                body: vec![
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 1 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        }
+                    ],
+                    vec![
+                        MdTableCell {
+                            content: vec![],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 4 ")
+                            }],
+                            alignment: TableAlignment::Left,
+                            is_header: false,
+                        }
+                    ]
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn table_with_missing_cell() {
+        init_test_config();
+        assert_eq!(
+            parse_blocks(group_lines_to_blocks(vec![
+                tokenize("| Header 1 | Header 2 |"),
+                tokenize("| -- | -- |"),
+                tokenize("| Cell 1 | Cell 2 |"),
+                tokenize("| Cell 3 |")
+            ])),
+            vec![Table {
+                headers: vec![
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 1 ")
+                        }],
+                        alignment: TableAlignment::None,
+                        is_header: true,
+                    },
+                    MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Header 2 ")
+                        }],
+                        alignment: TableAlignment::None,
+                        is_header: true,
+                    }
+                ],
+                body: vec![
+                    vec![
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 1 ")
+                            }],
+                            alignment: TableAlignment::None,
+                            is_header: false,
+                        },
+                        MdTableCell {
+                            content: vec![Text {
+                                content: String::from(" Cell 2 ")
+                            }],
+                            alignment: TableAlignment::None,
+                            is_header: false,
+                        }
+                    ],
+                    vec![MdTableCell {
+                        content: vec![Text {
+                            content: String::from(" Cell 3 ")
+                        }],
+                        alignment: TableAlignment::None,
+                        is_header: false,
+                    }]
+                ]
+            }]
+        )
+    }
 }
 
 mod html_generation {
@@ -1662,6 +1779,40 @@ mod html_generation {
                 .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
                 .collect::<String>(),
                 "<table><thead><tr><th style=\"text-align:left;\"> Header 1 </th><th style=\"text-align:left;\"> Header 2 </th></tr></thead><tbody><tr><td style=\"text-align:left;\"> <b>Bold Cell</b> </td><td style=\"text-align:left;\"> <i>Italic Cell</i> </td></tr><tr><td style=\"text-align:left;\"> <a href=\"http://example.com\" target=\"_blank\">Link⮺</a> </td><td style=\"text-align:left;\"> <img src=\"http://example.com/image.png\" alt=\"Image\"/> </td></tr></tbody></table>"
+            );
+        }
+
+        #[test]
+        fn table_with_empty_cells() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![
+                    tokenize("| Header 1 | Header 2 |"),
+                    tokenize("| :-- | :-- |"),
+                    tokenize("| Cell 1 ||"),
+                    tokenize("|| Cell 4 |")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<table><thead><tr><th style=\"text-align:left;\"> Header 1 </th><th style=\"text-align:left;\"> Header 2 </th></tr></thead><tbody><tr><td style=\"text-align:left;\"> Cell 1 </td><td style=\"text-align:left;\"></td></tr><tr><td style=\"text-align:left;\"></td><td style=\"text-align:left;\"> Cell 4 </td></tr></tbody></table>"
+            );
+        }
+
+        #[test]
+        fn table_with_missing_cell() {
+            init_test_config();
+            assert_eq!(
+                parse_blocks(group_lines_to_blocks(vec![
+                    tokenize("| Header 1 | Header 2 |"),
+                    tokenize("| -- | -- |"),
+                    tokenize("| Cell 1 | Cell 2 |"),
+                    tokenize("| Cell 3 |")
+                ]))
+                .iter()
+                .map(|el| el.to_html("test_output", "test_input", "test_rel_path"))
+                .collect::<String>(),
+                "<table><thead><tr><th style=\"text-align:left;\"> Header 1 </th><th style=\"text-align:left;\"> Header 2 </th></tr></thead><tbody><tr><td style=\"text-align:left;\"> Cell 1 </td><td style=\"text-align:left;\"> Cell 2 </td></tr><tr><td style=\"text-align:left;\"> Cell 3 </td></tr></tbody></table>"
             );
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,6 +150,27 @@ pub struct MdTableCell {
     pub is_header: bool,
 }
 
+impl ToHtml for MdTableCell {
+    fn to_html(&self, output_dir: &str, input_dir: &str, html_rel_path: &str) -> String {
+        let inner_html = self
+            .content
+            .iter()
+            .map(|el| el.to_html(output_dir, input_dir, html_rel_path))
+            .collect::<String>();
+
+        let text_alignment = match self.alignment {
+            TableAlignment::Left | TableAlignment::None => "left",
+            TableAlignment::Center => "center",
+            TableAlignment::Right => "right",
+        };
+
+        match self.is_header {
+            true => format!("<th style=\"text-align:{text_alignment};\">{inner_html}</th>"),
+            false => format!("<td style=\"text-align:{text_alignment};\">{inner_html}</td>"),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum TableAlignment {
     Left,

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,6 +139,21 @@ impl ToHtml for MdListItem {
     }
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub struct MdTableCell {
+    pub content: Vec<MdInlineElement>,
+    pub alignment: TableAlignment,
+    pub is_header: bool,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum TableAlignment {
+    Left,
+    Center,
+    Right,
+    None,
+}
+
 /// Represents inline markdown elements (text, bold/italic, link, etc.)
 #[derive(Debug, PartialEq, Clone)]
 pub enum MdInlineElement {

--- a/src/types.rs
+++ b/src/types.rs
@@ -166,6 +166,7 @@ impl ToHtml for MdListItem {
     }
 }
 
+/// Represents a cell in a markdown table.
 #[derive(Debug, PartialEq, Clone)]
 pub struct MdTableCell {
     pub content: Vec<MdInlineElement>,
@@ -194,6 +195,7 @@ impl ToHtml for MdTableCell {
     }
 }
 
+/// Represents the alignment of table cells in markdown tables.
 #[derive(Debug, PartialEq, Clone)]
 pub enum TableAlignment {
     Left,

--- a/src/types.rs
+++ b/src/types.rs
@@ -105,6 +105,29 @@ impl ToHtml for MdBlockElement {
                     .collect::<String>();
                 format!("<ol>{inner_items}</ol>")
             }
+            MdBlockElement::Table { headers, body } => {
+                let header_html = headers
+                    .iter()
+                    .map(|cell| cell.to_html(output_dir, input_dir, html_rel_path))
+                    .collect::<String>();
+
+                let body_html = body
+                    .iter()
+                    .map(|row| {
+                        let cell_html = row
+                            .iter()
+                            .map(|cell| cell.to_html(output_dir, input_dir, html_rel_path))
+                            .collect::<String>();
+
+                        format!("<tr>{cell_html}</tr>")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+
+                format!(
+                    "<table><thead><tr>{header_html}</tr></thead><tbody>{body_html}</tbody></table>"
+                )
+            }
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,7 @@ pub enum Token {
     CloseBracket,
     OpenParenthesis,
     CloseParenthesis,
+    TableCellSeparator,
     OrderedListMarker(String),
     Whitespace,
     CodeTick,

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,6 +56,10 @@ pub enum MdBlockElement {
     OrderedList {
         items: Vec<MdListItem>,
     },
+    Table {
+        headers: Vec<MdTableCell>,
+        body: Vec<Vec<MdTableCell>>,
+    },
 }
 
 impl ToHtml for MdBlockElement {


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added support for GitHub-style markdown tables. While it isn't defined by Commonmark, I tend to use them quite a bit in my studies so I figured it would be a nice thing to have.

## More Details

<!-- Describe the changes made in this pull request -->
### Types
- There is now a `Token::TableCellSeparator` variant
- There is now a `TableAlignment` enum with "Left", "Center", "Right", and "None" variants
  - These are denoted by ":--", ":-:", "--:", and "---" respectively (the number of dashes can vary)
- There is now an `MdTableCell` with the following attributes:
  - `content: Vec<MdInlineElement>`
  - `alignment: TableAlignment`
  - `is_header: bool`
- There is now an `MdBlockElement::Table` variant with the following attributes:
  - `headers: Vec<MdTableCell>`
  - `body: Vec<Vec<MdTableCell>>`

### Parsing
- Any loose `TableCellSeparator` tokens will be pushed to inline elements as "|"

## Test Updates

<!-- Describe the tests that you created for this pull request -->

- There are tests for different column alignments in `parser::test::block`
- There is a test for cells with inline elements in their contents in `parser::test::block`
- There are equivalent tests for the HTML generation of tables in `parser::test::html_generation::block`

## Dependency Updates

<!-- List any new dependencies added in this pull request -->

- `Toml` has been bumped up to `v0.9.2`

## Screenshots

<!-- Add screenshots to help showcase your changes -->
Given this input (GitHub tables with no alignment default to left-aligned text):
```md
| Header 1 | Header 2 |
| --- | --- |
| Cell 1 | Cell 2 |
| Cell 3 | Cell 4 |
```

The following table is generated:
<img width="1090" height="390" alt="image" src="https://github.com/user-attachments/assets/4652f06d-daeb-45cb-b3e9-46950a0f73cf" />

And given this table with mixed alignments:
```md
| Header 1 | Header 2 | Header 3 |
| :------- | :------: | -------: |
| Cell 1   |  Cell 2  |   Cell 3 |
| Cell 4   |  Cell 5  |   Cell 6 |
```

The following table is generated:
<img width="1120" height="372" alt="image" src="https://github.com/user-attachments/assets/44b2efa0-5df9-4d98-8b66-a991502eb9d4" />
