### PR TITLE
Add logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +141,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +209,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +249,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +271,21 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -234,11 +317,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rust_mark"
 version = "1.0.0"
 dependencies = [
  "clap",
  "dirs",
+ "env_logger",
+ "log",
  "serde",
  "toml",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2024"
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
 dirs = "6.0.0"
+env_logger = "0.11.8"
+log = "0.4.27"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9.2"
 unicode-segmentation = "1.12.0"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can also use the following CLI arguments to customize the behavior of RustMa
 - `-c, --config <CONFIG>`: Specify a custom configuration file (default: `./config.toml`).
 - `-o, --output-dir <OUTPUT_DIR>`: Specify the output directory for the generated HTML files (default: `/output`).
 - `-r, --recursive`: Recursively parse all Markdown files in the specified directory and its subdirectories. (default: false if not present)
+- `-v, --verbose`: Enable verbose output, which will print additional information while the program is running.
 - `-h, --help`: Display help information.
 - `-V, --version`: Display the version of RustMark.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 //! This module handles the configuration I/O for the application.
+use log::{error, info};
 use serde::{Deserialize, Serialize};
 
 use crate::CONFIG;
@@ -42,7 +43,7 @@ impl Config {
     pub fn from_file(file_path: &str) -> Result<Self, String> {
         // If the user provided a config file, try to load the config from it
         if !file_path.is_empty() {
-            println!("Loading config from: {}", file_path);
+            info!("Loading config from file: {}", file_path);
             let contents = std::fs::read_to_string(file_path)
                 .map_err(|e| format!("Failed to read config file: {}", e))?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,7 +95,7 @@ impl Config {
 pub fn init_config(config_path: &str) -> Result<(), Box<dyn std::error::Error>> {
     CONFIG.get_or_init(|| {
         Config::from_file(config_path).unwrap_or_else(|err| {
-            eprintln!("Error loading config: {}", err);
+            error!("Failed to load config: {}", err);
             std::process::exit(1);
         })
     });

--- a/src/io.rs
+++ b/src/io.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use dirs::config_dir;
+use log::info;
 
 use crate::config::Config;
 use crate::html_generator::generate_default_css;
@@ -128,7 +129,7 @@ pub fn write_html_to_file(
     output_dir: &str,
     input_filepath: &str,
 ) -> Result<(), Box<dyn Error>> {
-    println!("Writing output to directory: {}", output_dir);
+    info!("Writing output to directory: {}", output_dir);
     let output_dir = Path::new(output_dir).join(input_filepath);
 
     if let Some(parent) = output_dir.parent() {
@@ -157,7 +158,7 @@ pub fn write_html_to_file(
         )
     })?;
 
-    println!("HTML written to: {}", output_dir.display());
+    info!("HTML written to: {}", output_dir.display());
     Ok(())
 }
 
@@ -282,7 +283,7 @@ pub fn write_default_config(default_config: &Config) -> Result<(), String> {
         return Ok(());
     }
 
-    println!(
+    info!(
         "Config file does not exist, creating default config at: {}",
         config_path.display()
     );
@@ -301,7 +302,7 @@ pub fn write_default_config(default_config: &Config) -> Result<(), String> {
     file.write_all(default_config_content.as_bytes())
         .map_err(|e| format!("Failed to write to config file: {}", e))?;
 
-    println!("Default config file created at: {}", config_path.display());
+    info!("Default config file created at: {}", config_path.display());
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod utils;
 
 use clap::{Parser, command};
 use env_logger::Env;
-use log::info;
+use log::{error, info};
 use std::error::Error;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -46,6 +46,19 @@ struct Cli {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    match run() {
+        Ok(_) => {
+            info!("Static site generation completed successfully.");
+            Ok(())
+        }
+        Err(e) => {
+            error!("An error occurred: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     let input_dir = &cli.input_dir;
     let config_path = &cli.config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut file_names: Vec<String> = Vec::new();
 
     for (file_path, file_content) in file_contents {
+        info!("Generating HTML for file: {}", file_path);
         generate_static_site(&cli, &file_path, file_content)?;
         file_names.push(file_path);
     }
@@ -72,19 +73,19 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let css_file = CONFIG.get().unwrap().html.css_file.clone();
     if css_file != "default" && !css_file.is_empty() {
-        println!("Using custom CSS file: {}", css_file);
+        info!("Using custom CSS file: {}", css_file);
         copy_css_to_output_dir(&css_file, &cli.output_dir)?;
     } else {
-        println!("Using default CSS file.");
+        info!("Using default CSS file.");
         write_default_css_file(&cli.output_dir)?;
     }
 
     let favicon_path = CONFIG.get().unwrap().html.favicon_file.clone();
     if !favicon_path.is_empty() {
-        println!("Copying favicon from: {}", favicon_path);
+        info!("Copying favicon from: {}", favicon_path);
         copy_favicon_to_output_dir(&favicon_path, &cli.output_dir)?;
     } else {
-        println!("No favicon specified in config.");
+        info!("No favicon specified in config.");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod utils;
 
 use clap::{Parser, command};
 use env_logger::Env;
+use log::info;
 use std::error::Error;
 use std::path::Path;
 use std::sync::OnceLock;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod types;
 mod utils;
 
 use clap::{Parser, command};
+use env_logger::Env;
 use std::error::Error;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -50,6 +51,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let run_recursively = &cli.recursive;
 
     // Setup
+    let env = if cli.verbose {
+        Env::default().default_filter_or("info")
+    } else {
+        Env::default().default_filter_or("warn")
+    };
+    env_logger::Builder::from_env(env).init();
+
     init_config(config_path)?;
     let file_contents = read_input_dir(input_dir, run_recursively)?;
     let mut file_names: Vec<String> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ struct Cli {
     output_dir: String,
     #[arg(short, long, default_value = "false")]
     recursive: bool,
+    #[arg(short, long, default_value = "false")]
+    verbose: bool,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,8 @@
 //! It provides functions to parse block-level elements like headings, lists, and code blocks,
 //! as well as inline elements like links, images, and emphasis.
 
+use log::warn;
+
 use crate::CONFIG;
 use crate::types::{
     Delimiter, MdBlockElement, MdInlineElement, MdListItem, MdTableCell, TableAlignment, Token,
@@ -311,7 +313,10 @@ pub fn parse_table(line: Vec<Token>) -> MdBlockElement {
             let content: String = cell_content
                 .iter()
                 .filter_map(|token| match token {
-                    Token::Text(s) => Some(s.clone()),
+                    Token::Text(s) => {
+                        warn!("Table alignment should not contain text as it could result in unexpected behavior: {s}");
+                        Some(s.clone())
+                    }
                     Token::Punctuation(s) => Some(s.clone()),
                     Token::ThematicBreak => Some("---".to_string()),
                     _ => None,
@@ -493,8 +498,6 @@ pub fn parse_inline(markdown_tokens: Vec<Token>) -> Vec<MdInlineElement> {
         .for_each(|el| el.classify_flanking(&cursor.tokens));
 
     resolve_emphasis(&mut parsed_inline_elements, &mut delimiter_stack);
-
-    // Remove all placeholders
 
     parsed_inline_elements
 }

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -327,7 +327,6 @@ mod block {
     #[test]
     fn heading() {
         init_test_config();
-        println!("{:?}", tokenize("# Heading 1"));
         assert_eq!(
             parse_block(tokenize("# Heading 1")),
             Some(Header {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,8 @@
 //! This module defines the types used in the markdown parser, including tokens, inline elements,
 //! block elements, and a cursor for navigating through tokens.
 
+use log::warn;
+
 use crate::{io::copy_image_to_output_dir, utils::build_rel_prefix};
 
 pub trait ToHtml {
@@ -309,7 +311,7 @@ impl ToHtml for MdInlineElement {
                 // If the image uses a relative path, copy it to the output directory
                 if !url.starts_with("http") {
                     if let Err(e) = copy_image_to_output_dir(url, output_dir, input_dir) {
-                        eprintln!("Error copying image: {e}");
+                        warn!("Unable to copy image {url}: {e}");
                     }
 
                     // Update the URL to point to the copied image in the output directory


### PR DESCRIPTION
# Brief Overview

<!-- Describe the purpose of this pull request -->

In this pull request, I added a logger and a `-v`/`--verbose` flag to the CLI args.

## More Details

<!-- Describe the changes made in this pull request -->

- Users can now pass the `-v`/`--verbose` flag when running the program to enable "INFO"-level statements (starting/finishing working on files, generating html for X, etc.).
  - By default, only "ERROR" and "WARNING"-level statements will be shown
- The project now uses `env-logger` in tandem with `log` to replace many of the previously used `println!()` statements.

## Test Updates (if applicable)

<!-- Describe the tests that you created for this pull request -->

- Minor update, removed a `println!()` call from one test

## New Dependencies (if applicable)

<!-- List any new dependencies added in this pull request -->

- `log v0.4.27`: Used to establish the logger levels
- `env-logger v0.11.8`: Used to log information to the console